### PR TITLE
added invalid-xml style html parser

### DIFF
--- a/Sources/PerfectXML.swift
+++ b/Sources/PerfectXML.swift
@@ -282,6 +282,16 @@ public class XDocument: XNode {
 		super.init(toNodePtr(doc), document: nil)
 	}
 	
+	/// Parse the HTML source string and create the document, if possible.
+	public init?(fromHTML: String, charset: String) {
+		_ = XDocument.initialize
+		let source = xmlCharStrdup(fromHTML)
+		guard let doc = htmlParseDoc(source, charset) else {
+			return nil
+		}
+		super.init(toNodePtr(doc), document: nil)
+	}
+
 	init(_ ptr: xmlDocPtr) {
 		super.init(toNodePtr(ptr), document: nil)
 	}


### PR DESCRIPTION
Non-XHTML style html parser initialization.

This PR is depended on https://github.com/PerfectlySoft/Perfect-libxml2/pull/1 .
So, if you like this and when you merge this, please merge the depended PR first.
And change version of Perfect-libxml2 and depended package version of this Repo, then merge this.

Thanks.
